### PR TITLE
Use official SPDX identifier for license

### DIFF
--- a/convention-plugins/src/main/kotlin/module.publication.gradle.kts
+++ b/convention-plugins/src/main/kotlin/module.publication.gradle.kts
@@ -42,7 +42,7 @@ publishing {
 
             licenses {
                 license {
-                    name.set("The Apache License, Version 2.0")
+                    name.set("Apache-2.0")
                     url.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
                 }
             }


### PR DESCRIPTION
Small update for #7 

You can find the official SPDX identifier list here: https://spdx.org/licenses/